### PR TITLE
Issue: Sfagent was not restarted automatically upon instance restart.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -362,6 +362,15 @@ start)
                 printf "%s\n" "Fail. Check logs $LOG_PATH"
                 exit 1
         fi
+        CMD1="update-rc.d sfagent defaults"
+        echo $CMD1
+        $CMD1 &
+        if [ $? -eq 0 ]; then
+                printf "\n" "symbolic link added for sfagent"
+        else
+                printf "%s\n" "Failed while adding symbolic link for sfagent. Check logs $LOG_PATH"
+                exit 1
+        fi
 ;;
 status)
         printf "%-50s" "Checking $NAME..."


### PR DESCRIPTION
Fix: Symbolic link for sfagent needs to be explicitly added.So added script for symbolic link updation.
Test: Tested in Ubuntu14 environment.