### PR TITLE
Added the support for statsd rules to be added to the /opt/sfagent/st…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -193,11 +193,13 @@ upgrade_apm_agent()
             ls -l sfagent* checksum* >/dev/null
             tar -zxvf sfagent*linux_$ARCH.tar.gz >/dev/null
             mkdir -p $AGENTDIR/certs
+            mkdir -p $AGENTDIR/statsd_rules
             mv -f sfagent $AGENTDIR
             mv -f jolokia.jar $AGENTDIR
             mv -f mappings/* $AGENTDIR/mappings/
             mv -f scripts/* $AGENTDIR/scripts/
             mv -f certs/* $AGENTDIR/certs/
+            mv -f statsd/* $AGENTDIR/statsd_rules/
             mv -f normalization/* $AGENTDIR/normalization/
             mv -f config.yaml.sample $AGENTDIR/config.yaml.sample
             
@@ -309,12 +311,14 @@ install_apm_agent()
     mkdir -p $AGENTDIR/scripts
     mkdir -p $AGENTDIR/certs
     mkdir -p $AGENTDIR/normalization
+    mkdir -p $AGENTDIR/statsd_rules
     mv sfagent $AGENTDIR
     mv jolokia.jar $AGENTDIR
     mv mappings $AGENTDIR/.
     mv scripts $AGENTDIR/.
     mv certs $AGENTDIR/.
     mv normalization $AGENTDIR/.
+    mv statsd/* $AGENTDIR/statsd_rules
     mv config.yaml.sample $AGENTDIR/config.yaml.sample
     cat > $AGENTDIR/config.yaml <<EOF
 agent:


### PR DESCRIPTION
…atsd_rules folder:

Issue:
the rules files of statsd were not packed with the binary earlier so the statsd rules were not present in /opt/sfagent folder.
Fix:
added the support of bundling statsd rules in the repo sf-apm-agent, and in this repo apm-agent we are creating a repo in the /opt/sfagent and naming it statsd_rules .
Test:
tested locally installing the agent using the install.sh and verifying the contents in /opt/sfagent folder , found statsd_rules folder with rules.txt files in it.