### PR TITLE
Updated sending upgrade status flow

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -263,7 +263,7 @@ check_and_send_status()
     if [ -e /tmp/upgrade_status.json ]
     then
         logit "automated upgrade sending upgarde status"
-        status = $1
+        status=$1
         logit "sfagent running response code $status" 
         if [ "$status" -eq "success" ]
         then


### PR DESCRIPTION
Root cause: extra spaces in status makes it to be considered as a command while assigning value to status Changes made: removed spaces from status assignment Testcases :
When agent is upgraded from UI, after upgrade is successful from backend, it shows a success on the UI with upgraded agent version