### PR TITLE
Updated sending upgrade status flow

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -265,7 +265,7 @@ check_and_send_status()
         logit "automated upgrade sending upgarde status"
         status=$1
         logit "sfagent running response code $status" 
-        if [ "$status" -eq "success" ]
+        if [ "$status" = "success" ]
         then
 	    buildinfo=$($AGENTDIR/sfagent --version | tr '\n' ',')
             logit "upgraded buildinfo $buildinfo"


### PR DESCRIPTION
Root cause: error in comparison 
Changes made: changed comparison of  status to success from -eq to =  Testcase:
When agent is upgraded from UI, after upgrade is successful from backend, it shows a success on the UI with upgraded agent version