### PR TITLE
SNP-5867 Error during Sfagent upgrade

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -122,11 +122,11 @@ upgrade_fluent_bit()
 upgrade_sftrace_agent()
 {
     wget $SFTRACE_AGENT_x86_64
-    mv -f /opt/sfagent/sftrace/java/elasticapm.properties .
+    [ -f $AGENTDIR/sftrace/java/elasticapm.properties ] && mv -f /opt/sfagent/sftrace/java/elasticapm.properties .
     rm -rf /opt/sfagent/sftrace
     rm -rf /bin/sftrace
     tar -zxvf sftrace-agent.tar.gz >/dev/null && mv -f sftrace /opt/sfagent && mv -f /opt/sfagent/sftrace/sftrace /bin && mv -f /opt/sfagent/sftrace/java/sftrace /opt/sfagent/sftrace
-    mv -f elasticapm.properties /opt/sfagent/sftrace/java/
+    [ -f elasticapm.properties ] && mv -f elasticapm.properties /opt/sfagent/sftrace/java/
     echo "Upgrade sftrace java-agent and python-agent completed"
 
 }


### PR DESCRIPTION
Issue:
   Error during Sfagent upgrade and not sure if upgrade went successful or not
Root cause:
   Trying to move elasticapm.properties to sftrace/java when it not present 
changes made:
   Moving elasticapm.properties file after checking it's presence
Test Case:
  agent upgrade is successful
![sftrace upgrade](https://user-images.githubusercontent.com/108322039/230056009-3cae14f4-047a-471d-85bd-664a5e2d680d.PNG)
