### PR TITLE
Issue: netcat/nc installation not happening for amazon centOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,14 +30,37 @@ logit()
     echo "[$(date +%d/%m/%Y-%T)] - ${*}"
 }
 
+check_nc_installation()
+{
+    command -v "$1" >/dev/null 2>&1
+}
+
 ensure_system_packages()
 {   
     logit "install required system packages"
     if [ "$ID" = "debian" ] || [ "$ID" = "ubuntu" ]; then
         apt install -qy curl wget netcat logrotate sysstat &>/dev/null
+        if [ check_nc_installation "netcat" -eq 0 ]; then
+            logit "netcat (nc) command is installed."
+        else
+            logit "installing netcat command"
+            apt install netcat &>/dev/null
+            if [ check_nc_installation "netcat" -ne 0 ]; then
+                logit "Unable to install netcat command. Please install it manually"
+            fi
+        fi
     fi
-    if [ "$ID" = "centos" ]; then
+    if [ "$ID" = "centos" ] || [ "$ID" = "amzn"]; then
         yum install -y curl wget nc logrotate sysstat &>/dev/null
+        if [ check_nc_installation "nc" -eq 0 ]; then
+            logit "netcat (nc) command is installed."
+        else
+            logit "installing netcat command"
+            yum install -y nc &>/dev/null
+            if [ check_nc_installation "nc" -ne 0 ]; then
+                logit "Unable to install nc command. Please install it manually"
+            fi
+        fi
     fi
 }
 


### PR DESCRIPTION
Issue: netcat/nc installation not happening for amazon centOS
Root cause: the pre-req packages needed like netcat, curl etc is not installed by the script as check for os is made only for ubuntu and centos 
Changes made: i) Added check for "amzn" OS
              ii) Added extra check for installing netcat command, if any issue occurs during first installation, retry installing, any further issues occurs, the user is asked to install it manually
Testcases:
i) Check for netcat on ubuntu - should be able to reach forwarder server, netcat command is installed and successfully used 
ii) Check for netcat on centos - should be able to reach forwarder server, nc command is installed and successfully used
 iii) Check for netcat on amzn - should be able to reach forwarder server, nc command is installed and successfully used