### PR TITLE
Issue: netcat/nc installation not happening for amazon centOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,7 @@ ensure_system_packages()
             fi
         fi
     fi
-    if [ "$ID" = "centos" ] || [ "$ID" = "amzn"]; then
+    if [ "$ID" = "centos" ] || [ "$ID" = "amzn" ]; then
         yum install -y curl wget nc logrotate sysstat &>/dev/null
         if [ check_nc_installation "nc" -eq 0 ]; then
             logit "netcat (nc) command is installed."


### PR DESCRIPTION
Issue: netcat/nc installation not happening for amazon centOS 
Root cause: the pre-req packages needed like netcat, curl etc is not installed by the script as check for os is made only for ubuntu and centos 
Changes made: Added space before "]" in check for amzn 
Testcases:
i) Check for netcat on ubuntu - should be able to reach forwarder server, netcat command is installed and successfully used
ii) Check for netcat on centos - should be able to reach forwarder server, nc command is installed and successfully used 
iii) Check for netcat on amzn - should be able to reach forwarder server, nc command is installed and successfully used