### PR TITLE
Issue: To support sfagent installation for arm64 architecture

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,24 +40,24 @@ ensure_system_packages()
     logit "install required system packages"
     if [ "$ID" = "debian" ] || [ "$ID" = "ubuntu" ]; then
         apt install -qy curl wget netcat logrotate sysstat &>/dev/null
-        if [ check_nc_installation "netcat" -eq 0 ]; then
+        if check_nc_installation "netcat"; then
             logit "netcat (nc) command is installed."
         else
             logit "installing netcat command"
             apt install netcat &>/dev/null
-            if [ check_nc_installation "netcat" -ne 0 ]; then
+            if check_nc_installation "netcat" ; then
                 logit "Unable to install netcat command. Please install it manually"
             fi
         fi
     fi
     if [ "$ID" = "centos" ] || [ "$ID" = "amzn" ]; then
         yum install -y curl wget nc logrotate sysstat &>/dev/null
-        if [ check_nc_installation "nc" -eq 0 ]; then
+        if check_nc_installation "nc"; then
             logit "netcat (nc) command is installed."
         else
             logit "installing netcat command"
             yum install -y nc &>/dev/null
-            if [ check_nc_installation "nc" -ne 0 ]; then
+            if check_nc_installation "nc" ; then
                 logit "Unable to install nc command. Please install it manually"
             fi
         fi
@@ -84,15 +84,24 @@ EOF
 
 install_fluent_bit()
 {    
-    if [ "$SYSTEM_TYPE" = "systemd" ]; then
-        logit "download latest fluent-bit release"
+    if [ "$SYSTEM_TYPE" = "systemd" ] &&  [ "$ARCH" != "aarch64" ] ; then
+        logit "download latest fluent-bit release $ARCH"
         curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=100 \
         | grep -w "browser_download_url"|grep fluentbit \
         | head -n 1 \
         | cut -d":" -f 2,3 \
         | tr -d '"' \
-        | xargs wget -q 
+        | xargs wget -q
         logit "download latest fluent-bit release done"
+    elif [ "$SYSTEM_TYPE" = "systemd" ] && [ "$ARCH" = "aarch64" ]; then
+        logit "download latest fluent-bit release $ARCH"
+        curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=100 \
+        | grep -w "browser_download_url"|grep fluent-bit-arm \
+        | head -n 1 \
+        | cut -d":" -f 2,3 \
+        | tr -d '"' \
+        | xargs wget -q
+        logit "download latest arm64 fluent-bit release done"
     else
         logit "download centos 6 fluent-bit release"
         wget -q $FLUENT_CENTOS_6_BUILD
@@ -128,15 +137,24 @@ upgrade_fluent_bit()
     #fi
     [ -d /opt/td-agent-bit/bin_bkp ] && logit "remove old backup directories /opt/td-agent-bit/bin_bkp" && rm -rf /opt/td-agent-bit/bin_bkp
     cp -R /opt/td-agent-bit/bin /opt/td-agent-bit/bin_bkp
-    if [ "$SYSTEM_TYPE" = "systemd" ]; then
-        logit "download latest fluent-bit release"
+    if [ "$SYSTEM_TYPE" = "systemd" ] && [ "$ARCH" != "aarch64" ]; then
+        logit "download latest fluent-bit release for $ARCH"
         curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=100 \
         | grep -w "browser_download_url"|grep fluentbit \
         | head -n 1 \
         | cut -d":" -f 2,3 \
         | tr -d '"' \
-        | xargs wget -q 
+        | xargs wget -q
         logit "download latest fluent-bit release done"
+    elif [ "$SYSTEM_TYPE" = "systemd" ] && [ "$ARCH" = "aarch64" ]; then
+        logit "download latest fluent-bit release for $ARCH"
+        curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=100 \
+        | grep -w "browser_download_url"|grep fluent-bit-arm \
+        | head -n 1 \
+        | cut -d":" -f 2,3 \
+        | tr -d '"' \
+        | xargs wget -q
+        logit "download latest arm64 fluent-bit release done"
     else
         logit "download centos 6 build for fluent-bit"
         wget -q $FLUENT_CENTOS_6_BUILD
@@ -207,14 +225,22 @@ upgrade_apm_agent()
         | grep -w "browser_download_url" \
         | cut -d":" -f 2,3 \
         | tr -d '"' \
-        | xargs wget -q 
-        logit "download latest sfagent release done"
-        CHECKSUM=$(grep "$ARCH" checksums.txt | sha256sum --check | grep OK)
-        if [ ${#CHECKSUM} != 0 ]; then
+        | xargs wget -q
+        logit "download latest sfagent release done for $ARCH"
+	    if [ $ARCH = "aarch64" ];then
+            CHECKSUM=$(grep "arm64" checksums.txt | sha256sum --check | grep OK)
+        else
+	        CHECKSUM=$(grep "$ARCH" checksums.txt | sha256sum --check | grep OK)
+	    fi
+	    if [ ${#CHECKSUM} != 0 ]; then
             logit "checksum verification $CHECKSUM"
             ls -l sfagent* checksum* >/dev/null
-            tar -zxvf sfagent*linux_$ARCH.tar.gz >/dev/null
-            mkdir -p $AGENTDIR/certs
+	        if [ $ARCH = "aarch64" ]; then
+		        tar -zxvf sfagent*linux_arm64.tar.gz >/dev/null
+            else
+		        tar -zxvf sfagent*linux_$ARCH.tar.gz >/dev/null
+	        fi
+	        mkdir -p $AGENTDIR/certs
             mkdir -p $AGENTDIR/statsd_rules
             mv -f sfagent $AGENTDIR
             mv -f jolokia.jar $AGENTDIR
@@ -321,9 +347,17 @@ install_apm_agent()
     | xargs wget -q
     logit "download latest sfagent release done"
     ls -l sfagent* checksum* >/dev/null
-    CHECKSUM=$(grep $ARCH checksums.txt | sha256sum --check | grep OK)
+    if [ $ARCH = "aarch64" ];then
+        CHECKSUM=$(grep "arm64" checksums.txt | sha256sum --check | grep OK)
+    else
+        CHECKSUM=$(grep $ARCH checksums.txt | sha256sum --check | grep OK)
+    fi
     logit "checksum verification $CHECKSUM"
-    tar -zxvf sfagent*linux_$ARCH.tar.gz >/dev/null
+    if [ $ARCH = "aarch64" ];then
+        tar -zxvf sfagent*linux_arm64.tar.gz >/dev/null
+    else
+	    tar -zxvf sfagent*linux_$ARCH.tar.gz >/dev/null
+    fi
     mkdir -p $AGENTDIR
     mkdir -p $AGENTDIR/mappings
     mkdir -p $AGENTDIR/scripts


### PR DESCRIPTION
Issue: To support sfagent installation for arm64 architecture
Root cause: Enhancement
Changes made: i) Added check for architecture for downloading fluent-bit and sfagent releases
              ii) Added check for architecture for calculating checksum
              iii) Added fix "for too many [" - function call returns 0/1, reused the return value instead of comparing return value with 0/1.
Testcases:
i) If architecture is found to be amd64, fluentbit and sfagent tar file compiled for amd will be downloaded and installed
ii) If architecture is found to be arm64, fluentbit and sfagent tar file compiled for arm will be downloaded and installed
Installation for AMD64(x86_64):
![image](https://github.com/snappyflow/apm-agent/assets/110602101/43e8c390-dce3-4c65-b871-116c76673858)

Installation for ARM64(AARCH64):
![image](https://github.com/snappyflow/apm-agent/assets/110602101/4700135a-b545-410e-9fc9-761f6621e761)
