### PR TITLE
Issue: sfagent to support arm64 architecture

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -86,7 +86,7 @@ install_fluent_bit()
 {    
     if [ "$SYSTEM_TYPE" = "systemd" ] &&  [ "$ARCH" != "aarch64" ] ; then
         logit "download latest fluent-bit release $ARCH"
-        curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=100 \
+        curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
         | grep -w "browser_download_url"|grep fluentbit \
         | head -n 1 \
         | cut -d":" -f 2,3 \
@@ -95,7 +95,7 @@ install_fluent_bit()
         logit "download latest fluent-bit release done"
     elif [ "$SYSTEM_TYPE" = "systemd" ] && [ "$ARCH" = "aarch64" ]; then
         logit "download latest fluent-bit release $ARCH"
-        curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=100 \
+        curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
         | grep -w "browser_download_url"|grep fluent-bit-arm \
         | head -n 1 \
         | cut -d":" -f 2,3 \
@@ -139,7 +139,7 @@ upgrade_fluent_bit()
     cp -R /opt/td-agent-bit/bin /opt/td-agent-bit/bin_bkp
     if [ "$SYSTEM_TYPE" = "systemd" ] && [ "$ARCH" != "aarch64" ]; then
         logit "download latest fluent-bit release for $ARCH"
-        curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=100 \
+        curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
         | grep -w "browser_download_url"|grep fluentbit \
         | head -n 1 \
         | cut -d":" -f 2,3 \
@@ -148,7 +148,7 @@ upgrade_fluent_bit()
         logit "download latest fluent-bit release done"
     elif [ "$SYSTEM_TYPE" = "systemd" ] && [ "$ARCH" = "aarch64" ]; then
         logit "download latest fluent-bit release for $ARCH"
-        curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=100 \
+        curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
         | grep -w "browser_download_url"|grep fluent-bit-arm \
         | head -n 1 \
         | cut -d":" -f 2,3 \


### PR DESCRIPTION
Issue: To support sfagent installation for arm64 architecture
Root cause: Enhancement
Changes made: i) Changed per page limit from 100 to 500 while downloading fluentbit from release
Testcases:
i) when curl command is run to fetch releases, 500 releases are fetched. ( Increased because sometimes fluentbit release does not come in first 100 releases)
