### PR TITLE
Issue: sfagent installation to support ubuntu22

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -96,14 +96,25 @@ install_fluent_bit()
         | xargs wget -q
         logit "download latest fluent-bit release done"
     elif [ "$SYSTEM_TYPE" = "systemd" ] && [ "$ARCH" = "aarch64" ]; then
-        logit "download latest fluent-bit release $ARCH"
-        curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
-        | grep -w "browser_download_url"|grep "download/fluent-bit-arm" \
-        | head -n 1 \
-        | cut -d":" -f 2,3 \
-        | tr -d '"' \
-        | xargs wget -q
-        logit "download latest arm64 fluent-bit release done"
+        source /etc/os-release
+        if [ "$VERSION_ID" = "22.04" ] ; then
+            curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
+            | grep -w "browser_download_url"|grep "download/ubuntu22-fluent-bit-arm" \
+            | head -n 1 \
+            | cut -d":" -f 2,3 \
+            | tr -d '"' \
+            | xargs wget -q
+            logit "download latest fluent-bit for ubuntu 22 release done"
+        else
+            logit "download latest fluent-bit release $ARCH"
+            curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
+            | grep -w "browser_download_url"|grep "download/fluent-bit-arm" \
+            | head -n 1 \
+            | cut -d":" -f 2,3 \
+            | tr -d '"' \
+            | xargs wget -q
+            logit "download latest arm64 fluent-bit release done"
+        fi
     else
         logit "download centos 6 fluent-bit release"
         wget -q $FLUENT_CENTOS_6_BUILD
@@ -149,14 +160,25 @@ upgrade_fluent_bit()
         | xargs wget -q
         logit "download latest fluent-bit release done"
     elif [ "$SYSTEM_TYPE" = "systemd" ] && [ "$ARCH" = "aarch64" ]; then
-        logit "download latest fluent-bit release for $ARCH"
-        curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
-        | grep -w "browser_download_url"|grep "download/fluent-bit-arm" \
-        | head -n 1 \
-        | cut -d":" -f 2,3 \
-        | tr -d '"' \
-        | xargs wget -q
-        logit "download latest arm64 fluent-bit release done"
+        source /etc/os-release
+        if [ "$VERSION_ID" = "22.04" ] ; then
+            curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
+            | grep -w "browser_download_url"|grep "download/ubuntu22-fluent-bit-arm" \
+            | head -n 1 \
+            | cut -d":" -f 2,3 \
+            | tr -d '"' \
+            | xargs wget -q
+            logit "download latest fluent-bit for ubuntu 22 arm release done"
+        else
+            logit "download latest fluent-bit release for $ARCH"
+            curl -sL https://api.github.com/repos/snappyflow/apm-agent/releases?per_page=500 \
+            | grep -w "browser_download_url"|grep "download/fluent-bit-arm" \
+            | head -n 1 \
+            | cut -d":" -f 2,3 \
+            | tr -d '"' \
+            | xargs wget -q
+            logit "download latest arm64 fluent-bit release done"
+        fi
     else
         logit "download centos 6 build for fluent-bit"
         wget -q $FLUENT_CENTOS_6_BUILD


### PR DESCRIPTION
Root cause: enhancement
Changes made: i) Added check for underlying OS and version, based on the version associated fluentbit binary is downloaded Testcases:
i) When Os is ubuntu22, fluentbit binary compiled for ubuntu22 is downloaded
ii)When Os is ubuntu20, fluentbit binary compiled for ubuntu20 is downloaded.
![image](https://github.com/snappyflow/apm-agent/assets/110602101/49144db0-fff0-4e47-91bf-d4c0074dfdba)
![image](https://github.com/snappyflow/apm-agent/assets/110602101/07017f07-2756-47f0-9ca0-dd6696a9364e)
![image](https://github.com/snappyflow/apm-agent/assets/110602101/292b180b-dd62-4fcf-8e22-3d2a66a83696)
![image](https://github.com/snappyflow/apm-agent/assets/110602101/6347569f-f6b5-4819-afe6-898077aa9058)
![image](https://github.com/snappyflow/apm-agent/assets/110602101/31fe085f-38ab-4033-976e-9ac37479a107)
![image](https://github.com/snappyflow/apm-agent/assets/110602101/96c16408-e903-417b-b1d2-adef3ba91bfb)

